### PR TITLE
Fixing Issue #9

### DIFF
--- a/src/containers/Login.tsx
+++ b/src/containers/Login.tsx
@@ -12,6 +12,7 @@ import {extractTokenAndUserId} from '../utils/utils';
 // import {StackNavigationProp} from '@react-navigation/stack';
 // import {RootStackParamList} from '../routes';
 // type ProfileScreenNavigationProp = StackNavigationProp<RootStackParamList, 'Login'>;
+import {AppState} from '../utils/isAppLaunched';
 
 interface Props {
   // navigation: ProfileScreenNavigationProp,
@@ -26,7 +27,7 @@ export const Login: React.FC<Props> = () => {
   const [password, setPassword] = useState('');
   const [isLoading, setisLoading] = useState(false);
   const navigation = useNavigation();
-
+  const [triggerDeepLink, setTriggerDeepLink] = useState(false);
 
   function onLogin(username: string, password: string) {
     const validateObj = validate({emailAddress: username, password: password}, constraints);
@@ -75,7 +76,7 @@ export const Login: React.FC<Props> = () => {
 
   useEffect(() => {
     if (Platform.OS === "android") {
-      // Detect deep-linking for when the app is already launched
+      // Detect deep-linking when the app is already launched
       Linking.addEventListener('url', (event) => {
         if (event.url && event.url.length > 0) {
           let userId: string;
@@ -87,19 +88,23 @@ export const Login: React.FC<Props> = () => {
           navigation.navigate('ChangePWD', {id: userId, token: token});
         }
       });
-      // Detect deep-linking for when the app not yet launched
-      Linking.getInitialURL().then((url) => {
-        if (url && url.length > 0) {
-          let userId: string;
-          let token: string;
-          let returnValue = extractTokenAndUserId(url);
+      if (!AppState.isAppLaunched) {
+        // Detect deep-linking when the app not yet launched
+        Linking.getInitialURL().then((url) => {
+          if (url) {
+            let userId: string;
+            let token: string;
+            let returnValue = extractTokenAndUserId(url);
 
-          userId = returnValue.userId;
-          token = returnValue.token;
-          navigation.navigate('ChangePWD', {id: userId, token: token});
-        }
-      });
+            userId = returnValue.userId;
+            token = returnValue.token;
+            navigation.navigate('ChangePWD', {id: userId, token: token});
+          }
+        });
+      }
     }
+    AppState.isAppLaunched = true;
+    Object.freeze(AppState);
   }, [])
 
   useEffect(() => {

--- a/src/containers/Login.tsx
+++ b/src/containers/Login.tsx
@@ -27,7 +27,6 @@ export const Login: React.FC<Props> = () => {
   const [password, setPassword] = useState('');
   const [isLoading, setisLoading] = useState(false);
   const navigation = useNavigation();
-  const [triggerDeepLink, setTriggerDeepLink] = useState(false);
 
   function onLogin(username: string, password: string) {
     const validateObj = validate({emailAddress: username, password: password}, constraints);

--- a/src/utils/isAppLaunched.ts
+++ b/src/utils/isAppLaunched.ts
@@ -1,0 +1,3 @@
+export class AppState {
+    public static isAppLaunched: boolean = false;
+}


### PR DESCRIPTION
Hi,

This pull request is maily focused on the #9, the issue was related to deep linking on Android.

React-Native implements two functions to detect that the user got redirected to the application from an URL :

- Linking.addEventListener
- Linking.getInitialURL

What's the difference between these two ? One is to add an event that will be listening constantly to a specific event. In our case this is the event 'url' that he will be looking for to know if a user clicked on an link that redirect to the mobile app.

The other one, have the same behaviour as the 'addEventListener' but this one is used in case the app is closed whereas the function addEventListener only work when the app is launched.

Moving on into the issue, it appears that if I close my app, reset my password from the link sent to my mailbox, logged in and logged out, get redirected to the login page, I would get instantly redirect again to the change password page from the getInitialURL function.

Why would he redirect me again to that page when I was coming from the Home page since I was logging out ?

Since I was calling getInitialURLL method in the useEffect method without checking if the app was already loaded or not, it was triggered each time I was on the login page